### PR TITLE
Add git download to GitAuthenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ They wrap git operations with the credentials callback set:
 * [`GitAuthenticator::clone_repo()`]
 * [`GitAuthenticator::fetch()`]
 * [`GitAuthenticator::push()`]
+* [`GitAuthenticator::download()`]
 
 ## Customizing user prompts
 
@@ -95,4 +96,5 @@ let mut repo = repo_builder.clone(url, into);
 [`GitAuthenticator::clone_repo()`]: https://docs.rs/auth-git2/latest/auth_git2/struct.GitAuthenticator.html#method.clone_repo
 [`GitAuthenticator::fetch()`]: https://docs.rs/auth-git2/latest/auth_git2/struct.GitAuthenticator.html#method.fetch
 [`GitAuthenticator::push()`]: https://docs.rs/auth-git2/latest/auth_git2/struct.GitAuthenticator.html#method.push
+[`GitAuthenticator::download()`]: https://docs.rs/auth-git2/latest/auth_git2/struct.GitAuthenticator.html#method.download
 [`GitAuthenticator::set_prompter()`]: https://docs.rs/auth-git2/latest/auth_git2/struct.GitAuthenticator.html#method.set_prompter

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl GitAuthenticator {
 	///
 	/// If you need more control over the download options,
 	/// use [`Self::credentials()`] with a [`git2::Remote::download`].
-	pub fn download(&self, repo: &git2::Repository, remote: &mut git2::Remote, refspecs: &[&str], _reflog_msg: Option<&str>) -> Result<(), git2::Error> {
+	pub fn download(&self, repo: &git2::Repository, remote: &mut git2::Remote, refspecs: &[&str]) -> Result<(), git2::Error> {
 		let git_config = repo.config()?;
 		let mut fetch_options = git2::FetchOptions::new();
 		let mut remote_callbacks = git2::RemoteCallbacks::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,6 +458,7 @@ impl GitAuthenticator {
 		remote.download(refspecs, Some(&mut fetch_options))
 	}
 
+
 	/// Push to a remote using the git authenticator.
 	///
 	/// If you need more control over the push options,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,21 @@ impl GitAuthenticator {
 		remote.fetch(refspecs, Some(&mut fetch_options), reflog_msg)
 	}
 
+
+	/// Download from a remote using the git authenticator.
+	///
+	/// If you need more control over the download options,
+	/// use [`Self::credentials()`] with a [`git2::Remote::download`].
+	pub fn download(&self, repo: &git2::Repository, remote: &mut git2::Remote, refspecs: &[&str], _reflog_msg: Option<&str>) -> Result<(), git2::Error> {
+		let git_config = repo.config()?;
+		let mut fetch_options = git2::FetchOptions::new();
+		let mut remote_callbacks = git2::RemoteCallbacks::new();
+
+		remote_callbacks.credentials(self.credentials(&git_config));
+		fetch_options.remote_callbacks(remote_callbacks);
+		remote.download(refspecs, Some(&mut fetch_options))
+	}
+
 	/// Push to a remote using the git authenticator.
 	///
 	/// If you need more control over the push options,


### PR DESCRIPTION
Added support for git download for lfs repositories.  Tested locally with a separate cli tool I'm building.