### PR TITLE
fix: remove stray comma from id_ecdsa string in add_default_ssh_keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,7 +349,7 @@ impl GitAuthenticator {
 
 		let candidates = [
 			"id_rsa",
-			"id_ecdsa,",
+			"id_ecdsa",
 			"id_ecdsa_sk",
 			"id_ed25519",
 			"id_ed25519_sk",


### PR DESCRIPTION
Sorry for the previous pr, it's my first time doing one